### PR TITLE
Split color scheme at 0, add a new color

### DIFF
--- a/src/js/data/dataMethods.js
+++ b/src/js/data/dataMethods.js
@@ -106,10 +106,11 @@ const dataMethods = {
     const msaYearRange = [2010, 2016];
 
     const changeColorScale = d3.scaleThreshold()
-      .domain([-25, -5, 5, 25])
+      .domain([-50, -10, 0, 10, 50])
       .range([
         '#BC4E9F',
         '#E6B4D6',
+        '#fde8f7',
         '#E2F1FD',
         '#8BD5D5',
         '#009093',

--- a/src/js/histogram/histogramDataFunctions.js
+++ b/src/js/histogram/histogramDataFunctions.js
@@ -4,31 +4,23 @@ const getData = ({
   getValue,
   mobile,
 }) => {
-  const roundToFive = d => Math.round(d / 5) * 5;
+  const roundToTen = d => Math.round(d / 10) * 10;
   const changeSpan = d3.extent(records, getValue);
   const changeSpanUse = changeSpan.map((d, i) => {
-    let num = roundToFive(d);
-    if (num % 10 === 0) {
-      if (i === 0) {
-        num -= 5;
-      } else if (i === 1) {
-        num += 5;
-      }
-    }
-
+    const num = roundToTen(d);
     if (i === 0 && num < -295) {
-      return -305;
+      return -300;
     }
 
     if (i === 1 && num > 295) {
-      return 305;
+      return 300;
     }
     return num;
   });
 
 
   const getBucketSize = () => {
-    const testSize = roundToFive((changeSpanUse[1] - changeSpanUse[0]) / bucketCount);
+    const testSize = roundToTen((changeSpanUse[1] - changeSpanUse[0]) / bucketCount);
     let bucketSize;
     if (testSize < 5) {
       bucketSize = 5;

--- a/src/js/histogram/histogramLocalFunctions.js
+++ b/src/js/histogram/histogramLocalFunctions.js
@@ -70,8 +70,8 @@ const localFunctions = {
     let bucketText;
     if (bucket[0] < -100) {
       bucketText = `-100% to ${Math.round(bucket[1])}%`;
-    } else if (bucket[1] > 300) {
-      bucketText = '> 295%';
+    } else if (bucket[1] >= 300) {
+      bucketText = '> 290%';
     } else {
       bucketText = bucket.map(val => `${Math.round(val)}%`).join(' to ');
     }


### PR DESCRIPTION
This is a quick change to make the color scheme diverge from zero instead of having a class that spans zero. There are a couple things to double check, though...

@bwellington can you take a quick look to make sure I didn't do something that wrecks the histogram? I just changed the rounding function and it seems to be fine, but I don't entirely know how things work.

@davidheyman can you confirm if the change in class breaks is okay, or suggest a different one? As the histogram now breaks on 10s instead of 5s, the color class breaks should too.
Old: < -25% | -25 to -5 | -5 to 5 | 5 to 25 | > 25
New: < -50% | -50 to -10 | -10 to 0 | 0 to 10 | 10 to 50 | > 50