### PR TITLE
Update circle scale with indicator or year change

### DIFF
--- a/src/js/atlas/atlas.js
+++ b/src/js/atlas/atlas.js
@@ -30,6 +30,7 @@ const privateMethods = {
       onZoom,
       mobile,
       embedded,
+      radiusScale,
     } = props;
 
     const {
@@ -49,16 +50,14 @@ const privateMethods = {
       setAgencyNodes,
       drawAgencies,
       drawStates,
+      getRadiusScale,
+      setNodePositions,
+      getAgenciesTable,
     } = atlasNationalFunctions;
 
     const {
       toggleNationalLayers,
     } = privateMethods;
-
-
-    const {
-      radiusScale,
-    } = props;
 
     const {
       geoPath,
@@ -101,6 +100,13 @@ const privateMethods = {
       },
     });
 
+    setNodePositions({
+      nodes: props.nodes,
+      radiusScale,
+      logSimulationNodes: (newNodes) => {
+        props.nodes = newNodes;
+      },
+    });
 
     setMSANodes({
       nationalMapData,
@@ -111,12 +117,23 @@ const privateMethods = {
       },
     });
 
+    setNodePositions({
+      nodes: props.msaNodes,
+      radiusScale,
+      logSimulationNodes: (newNodes) => {
+        props.msaNodes = newNodes;
+      },
+    });
+
     const { nodes, msaNodes } = props;
+    props.radiusScale = getRadiusScale({
+      nodes: nationalDataView === 'ta' ? nodes : msaNodes,
+    });
     let agencies;
     if (nationalDataView === 'ta') {
       agencies = drawAgencies({
         jumpToMsa,
-        radiusScale,
+        radiusScale: props.radiusScale,
         dataProbe,
         layer: layers.agencies,
         nationalMapData,
@@ -129,7 +146,7 @@ const privateMethods = {
     } else {
       agencies = drawMSAs({
         jumpToMsa,
-        radiusScale,
+        radiusScale: props.radiusScale,
         dataProbe,
         layer: layers.agencies,
         nationalMapData,
@@ -200,7 +217,6 @@ const privateMethods = {
       projection,
       projectionModify,
       geoPath,
-      radiusScale,
       zoom,
     });
 

--- a/src/js/atlas/atlasGeoFunctions.js
+++ b/src/js/atlas/atlasGeoFunctions.js
@@ -138,45 +138,7 @@ const atlasMethods = {
     mapSVG.call(zoom);
   },
 
-  getAgenciesTable({
-    nationalMapData,
-    nationalDataView,
-  }) {
-    return nationalMapData
-      .reduce((accumulator, msa) => {
-        if (nationalDataView === 'ta') {
-          msa.ta.forEach((ta) => {
-            accumulator[ta.globalId] = ta;
-          });
-        } else {
-          accumulator[msa.globalId] = msa;
-        }
 
-        return accumulator;
-      }, {});
-  },
-  getUpdatedNodes({
-    nodes,
-    msaNodes,
-    nationalMapData,
-    nationalDataView,
-  }) {
-    const {
-      getAgenciesTable,
-    } = atlasMethods;
-
-    const agenciesTable = getAgenciesTable({ nationalMapData, nationalDataView });
-    const nodesToUse = nationalDataView === 'ta' ? nodes : msaNodes;
-    return nodesToUse
-      .map((node) => {
-        const nodeCopy = Object.assign({}, node);
-        const agency = agenciesTable[node.globalId];
-        if (agency === undefined) return nodeCopy;
-        nodeCopy.pctChange = agency.pctChange;
-        nodeCopy.firstAndLast = agency.firstAndLast;
-        return nodeCopy;
-      });
-  },
   setAgencyColors({
     agencies,
     changeColorScale,
@@ -185,18 +147,10 @@ const atlasMethods = {
     msaNodes,
     nationalDataView,
   }) {
-    const {
-      getUpdatedNodes,
-    } = atlasMethods;
-    const updatedNodes = getUpdatedNodes({
-      nodes,
-      msaNodes,
-      nationalMapData,
-      nationalDataView,
-    });
+    const nodesToUse = nationalDataView === 'ta' ? nodes : msaNodes;
 
     agencies
-      .data(updatedNodes, d => d.globalId)
+      .data(nodesToUse, d => d.globalId)
       .transition()
       .duration(500)
       .attrs({

--- a/src/js/atlas/atlasPublicFunctions.js
+++ b/src/js/atlas/atlasPublicFunctions.js
@@ -8,39 +8,6 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
     return this;
   },
 
-  updateYears() {
-    const props = privateProps.get(this);
-    // const {
-    //   setRadiusScale,
-    // } = privateMethods;
-
-    // setRadiusScale.call(this);
-
-    const {
-      nationalMapData,
-      agencies,
-      nodes,
-      msaNodes,
-      changeColorScale,
-      nationalDataView,
-    } = props;
-    const {
-      setAgencyColors,
-    } = atlasGeoFunctions;
-
-
-    setAgencyColors({
-      agencies,
-      changeColorScale,
-      nationalMapData,
-      nodes,
-      msaNodes,
-      nationalDataView,
-    });
-
-    return this;
-  },
-
   updateNationalMapData() {
     const props = privateProps.get(this);
     const {
@@ -50,19 +17,69 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
       nodes,
       msaNodes,
       nationalDataView,
+      projectionModify,
     } = props;
     const {
       // drawAgencies,
       setAgencyColors,
     } = atlasGeoFunctions;
 
+    const {
+      getRadiusScale,
+      setNodePositions,
+      zoomAgencies,
+      updateRadii,
+      getUpdatedNodes,
+    } = atlasNationalFunctions;
+
+    const updatedNodes = getUpdatedNodes({
+      nodes,
+      msaNodes,
+      nationalMapData,
+      nationalDataView,
+    });
+
+    Object.assign(props, {
+      nodes: updatedNodes.nodes,
+      msaNodes: updatedNodes.msaNodes,
+    });
+
+    const radiusScale = getRadiusScale({
+      nodes: nationalDataView === 'ta' ? props.nodes : props.msaNodes,
+    });
+
+    setNodePositions({
+      nodes: props.nodes,
+      radiusScale,
+      logSimulationNodes: (newNodes) => {
+        props.nodes = newNodes;
+      },
+    });
+
+    setNodePositions({
+      nodes: props.msaNodes,
+      radiusScale,
+      logSimulationNodes: (newNodes) => {
+        props.msaNodes = newNodes;
+      },
+    });
+
     setAgencyColors({
       agencies,
       changeColorScale,
       nationalMapData,
-      nodes,
-      msaNodes,
+      nodes: props.nodes,
+      msaNodes: props.msaNodes,
       nationalDataView,
+    });
+
+    updateRadii({
+      agencies,
+    });
+
+    zoomAgencies({
+      agencies,
+      projectionModify,
     });
 
     return this;
@@ -78,7 +95,6 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
       updateHighlightedAgencies,
       mapFeatures,
       nationalDataView,
-      radiusScale,
       layers,
       projection,
       projectionModify,
@@ -92,16 +108,24 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
       drawAgencies,
       drawMSAs,
       zoomAgencies,
-    } = atlasNationalFunctions;
-    const {
+      getRadiusScale,
+      updateRadii,
       getUpdatedNodes,
-    } = atlasGeoFunctions;
+    } = atlasNationalFunctions;
+
+    const radiusScale = getRadiusScale({
+      nodes: nationalDataView === 'ta' ? props.nodes : props.msaNodes,
+    });
 
     const updatedNodes = getUpdatedNodes({
       nodes,
       msaNodes,
       nationalMapData,
       nationalDataView,
+    });
+    Object.assign(props, {
+      nodes: updatedNodes.nodes,
+      msaNodes: updatedNodes.msaNodes,
     });
     let agencies;
     if (nationalDataView === 'ta') {
@@ -115,7 +139,7 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
         changeColorScale,
         projectionModify,
         updateHighlightedAgencies,
-        nodes: updatedNodes,
+        nodes: props.nodes,
         logSimulationNodes: (newNodes) => {
           props.nodes = newNodes;
         },
@@ -140,7 +164,7 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
         changeColorScale,
         projectionModify,
         updateHighlightedAgencies,
-        msaNodes: updatedNodes,
+        msaNodes: props.msaNodes,
         logSimulationNodes: (newNodes) => {
           props.msaNodes = newNodes;
         },
@@ -154,6 +178,10 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
         agencies,
       });
     }
+
+    updateRadii({
+      agencies,
+    });
 
     return this;
   },

--- a/src/js/stateUpdate/stateUpdateYears.js
+++ b/src/js/stateUpdate/stateUpdateYears.js
@@ -20,7 +20,7 @@ const getStateUpdateYear = ({ components }) => function updateYears() {
       nationalMapData,
       years,
     })
-    .updateYears()
+    .updateNationalMapData()
     .updateInteractions();
 
   if (histogram !== null) {


### PR DESCRIPTION
Relevant to #65 and #67 I think. The scale of proportional symbols in national view updates with the currently selected indicator and year range. Size is based on the end year value only. (Could be an average of the two, otherwise?)

A catch with this, as currently written, is that the circle packing thing causes symbols to change position if they're rescaled, which could certainly be confusing (see first gif below for example). Alternatively, they could retain their original positions as set by the initial circle packing on load, the tradeoff being that symbols can overlap a lot when you're zoomed out (second gif).

![reposition](https://user-images.githubusercontent.com/3533462/73970753-aae6fa80-48eb-11ea-80d8-2960cf365702.gif)
 
![constant_position](https://user-images.githubusercontent.com/3533462/73970764-b20e0880-48eb-11ea-8145-10e30b35e178.gif)
