### PR TITLE
Use different colors for agencies/MSAs in compare mode

### DIFF
--- a/src/js/dropdown/compareDropdownMethods.js
+++ b/src/js/dropdown/compareDropdownMethods.js
@@ -1,3 +1,16 @@
+const compareColors = [
+  '#0f8fff',
+  '#ff5e4d',
+  '#8c6112',
+  '#ff9d2e',
+  '#c2ab00',
+  '#33a02c',
+  '#eb52d6',
+  '#707070',
+  '#00ad91',
+  '#bc80bd',
+];
+
 const pureMethods = {
   drawContent({
     nationalMapData,
@@ -9,7 +22,8 @@ const pureMethods = {
     const agenciesByRidership = nationalMapData.map(msa => msa.ta)
       .reduce((accumulator, ta) => [...accumulator, ...ta], [])
       .sort((a, b) => b.ntd[b.ntd.length - 1].upt - a.ntd[a.ntd.length - 1].upt)
-      .slice(0, 10);
+      .slice(0, 10)
+      .map((ta, i) => ({ compareColor: compareColors[i], ...ta }));
 
     // for the moment, this is actually MSAs by ridership
     const msaByPop = nationalMapData.map((msa) => {
@@ -18,7 +32,8 @@ const pureMethods = {
       return msaCopy;
     })
       .sort((a, b) => b.population - a.population)
-      .slice(0, 10);
+      .slice(0, 10)
+      .map((msa, i) => ({ compareColor: compareColors[i], ...msa }));
 
     const compareList = [
       {

--- a/src/js/parallelCoordinatePlot/parallelCoordinatePlot.js
+++ b/src/js/parallelCoordinatePlot/parallelCoordinatePlot.js
@@ -97,7 +97,7 @@ class ParallelCoordinatePlot {
       maxValue: 100,
       highlightedAgencies: [],
       searchResult: null,
-      color: () => 'rgb(0,0,0)',
+      color: d => (d.compareColor || 'rgb(0,0,0)'),
     });
 
     const {

--- a/src/js/parallelCoordinatePlot/parallelCoordinatePlotFunctions.js
+++ b/src/js/parallelCoordinatePlot/parallelCoordinatePlotFunctions.js
@@ -108,7 +108,7 @@ const parallelCoordinatePlotFunctions = {
       .enter()
       .append('path')
       .style('fill', 'none')
-      .style('stroke', d => (msaScale ? d.color : color()))
+      .style('stroke', d => (msaScale ? d.color : color(d)))
       .style('opacity', 0)
       .attr('class', 'pcp-line')
       .attr('d', d => lineGenerator(d.indicators))
@@ -183,7 +183,7 @@ const parallelCoordinatePlotFunctions = {
       })
       .transition()
       .attr('d', d => lineGenerator(d.indicators))
-      .style('stroke', d => (msaScale ? d.color : color()))
+      .style('stroke', d => (msaScale ? d.color : color(d)))
       .style('opacity', agenciesData.length < 15 ? 0.75 : 0.1);
 
     return mergedLines;

--- a/src/js/sidebar/sidebar.js
+++ b/src/js/sidebar/sidebar.js
@@ -86,6 +86,7 @@ const privateMethods = {
       updateComparedAgencies,
       compareContainer,
       updateHighlightedAgencies,
+      compareColors,
     } = props;
 
     const rows = compareContainer.select('.sidebar__compare-rows')
@@ -96,12 +97,17 @@ const privateMethods = {
       .append('div')
       .attr('class', 'sidebar__compare-row')
       .on('mouseover', d => updateHighlightedAgencies([d]))
-      .on('mouseout', () => updateHighlightedAgencies([]))
+      .on('mouseout', () => updateHighlightedAgencies([]));
+    newRows.append('div');
+    newRows.append('span')
       .text(d => d.taName || d.name);
     newRows.append('i')
       .attr('class', 'fa fa-times');
 
-    newRows.merge(rows)
+    const allRows = newRows.merge(rows);
+    allRows.select('div')
+      .style('background-color', d => d.compareColor);
+    allRows
       .select('i')
       .on('click', (d) => {
         const others = comparedAgencies.slice()

--- a/src/js/sidebar/sidebarSparklineFunctions.js
+++ b/src/js/sidebar/sidebarSparklineFunctions.js
@@ -54,6 +54,7 @@ const sidebarSparkLineFunctions = {
       .each(function drawSparkline(d) {
         const container = d3.select(this);
 
+
         const sparkLine = new SparkLine({
           width: width * 0.4,
           container,
@@ -64,7 +65,7 @@ const sidebarSparkLineFunctions = {
           embedded,
           currentScale,
           expanded: (expandedSparklines === true),
-          color: currentScale === 'msa',
+          color: true,
         });
         sparkLines.push(sparkLine);
       });

--- a/src/js/sparkLine/sparkLineFunctions.js
+++ b/src/js/sparkLine/sparkLineFunctions.js
@@ -139,7 +139,7 @@ const sparkLineFunctions = {
         if (color) {
           d3.select(this)
             .styles({
-              stroke: d.color,
+              stroke: d.compareColor || d.color,
               'stroke-width': 1,
             });
         }

--- a/src/js/stateMethods/stateGetCurrentAgenciesData.js
+++ b/src/js/stateMethods/stateGetCurrentAgenciesData.js
@@ -44,6 +44,10 @@ const getGetCurrentAgenciesData = ({ data }) => function getCurrentAgenciesData(
           globalId,
           color,
         };
+        if (comparedAgencies.length) {
+          const compared = comparedAgencies.find(a => a.globalId === agency.globalId);
+          agencyCopy.compareColor = compared.compareColor;
+        }
         const agencyIndicators = indicatorSummaries.map((indicator) => {
           const {
             text,
@@ -97,6 +101,11 @@ const getGetCurrentAgenciesData = ({ data }) => function getCurrentAgenciesData(
         globalId,
         name,
       };
+
+      if (comparedAgencies.length) {
+        const compared = comparedAgencies.find(a => a.globalId === msa.globalId);
+        msaCopy.compareColor = compared.compareColor;
+      }
 
       msaCopy.indicators = indicatorSummaries.map((indicator) => {
         const {

--- a/src/scss/_sidebar.scss
+++ b/src/scss/_sidebar.scss
@@ -308,7 +308,7 @@ path.pcp-line:hover, path.pcp-line.highlight, path.pcp-line.search-result {
 
 .sidebar__compare-row {
   display: flex;
-  justify-content: space-between;
+  align-items: center;
   margin: 0 20px;
   border-bottom: 1px solid #ccc;
   padding: 10px 0;
@@ -320,6 +320,16 @@ path.pcp-line:hover, path.pcp-line.highlight, path.pcp-line.search-result {
 
 .sidebar__compare-list.visible {
   display: block;
+}
+
+.sidebar__compare-row div {
+  width: 12px;
+  height: 12px;
+  margin-right: 5px;
+}
+
+.sidebar__compare-row span {
+  flex: 1;
 }
 
 .sidebar__compare-row .fa-times {


### PR DESCRIPTION
#61

Below is what it looks like. (PCP uses colors too.) Comparison is limited to 10 and the map tooltip shows a warning once the limit is reached. It uses the same set of colors as agencies in MSA-level map, plus one more purple from ColorBrewer. They're just assigned in order as you select agencies/MSAs for comparison.

A note or question here is that the legend, as it currently stands, is not a _filter_ but rather retains the original functionality: you can remove items but you can't toggle their visibility on and off.

![Screen Shot 2020-02-21 at 11 44 43 AM](https://user-images.githubusercontent.com/3533462/75053962-24601a80-54a0-11ea-8928-d8d32d290f08.png)
