### PR TITLE
Map scales

### DIFF
--- a/src/js/atlas/atlas.js
+++ b/src/js/atlas/atlas.js
@@ -127,7 +127,7 @@ const privateMethods = {
 
     const { nodes, msaNodes } = props;
     props.radiusScale = getRadiusScale({
-      nodes: nationalDataView === 'ta' ? nodes : msaNodes,
+      nationalMapData,
     });
     let agencies;
     if (nationalDataView === 'ta') {

--- a/src/js/atlas/atlasGeoFunctions.js
+++ b/src/js/atlas/atlasGeoFunctions.js
@@ -24,7 +24,8 @@ const atlasMethods = {
     mobile,
     embedded,
   }) {
-    const initialScale = d3.min([width, height]) * 1.25;
+    const initialScaleDesktop = Math.max(700, d3.min([width, height]) * 2);
+    const initialScaleMobile = d3.min([width, height]) * 1.25;
     const projection = d3.geoAlbersUsa()
       .translate([width / 2, height / 2]);
 
@@ -34,14 +35,12 @@ const atlasMethods = {
      * instead of doing this we should just calculate scale based on viewport + USA bounds
      * @private
      */
-    if (mobile || embedded) {
-      [
-        projection,
-        projectionModify,
-      ].forEach((prop) => {
-        prop.scale(initialScale);
-      });
-    }
+    [
+      projection,
+      projectionModify,
+    ].forEach((prop) => {
+      prop.scale(mobile || embedded ? initialScaleMobile : initialScaleDesktop);
+    });
     const geoPath = d3.geoPath()
       .projection(projection);
 

--- a/src/js/atlas/atlasNationalFunctions.js
+++ b/src/js/atlas/atlasNationalFunctions.js
@@ -6,15 +6,19 @@ const topojson = Object.assign({}, topojsonBase, topojsonSimplify);
 
 const atlasNationalFunctions = {
   getRadiusScale({
-    nodes,
+    nationalMapData,
   }) {
-    const domain = d3.extent(nodes, d => d.firstAndLast[1]);
+    const min = d3.min(nationalMapData, d => d.firstAndLast[1]);
+    const mean = d3.mean(nationalMapData, d => d.firstAndLast[1]);
 
+    // scale based on min and some size roughly in the middle,
+    // trying to cut down on maps full of high values and big circles
     const scale = d3.scaleSqrt()
-      .domain(domain)
-      .range([5, 35]);
+      .domain([min, mean])
+      .range([5, 12]);
 
-    return d => (d === null ? 0 : scale(d));
+    // handle missing data; cap radius at 35
+    return d => (d === null ? 0 : Math.min(scale(d), 35));
   },
   drawStates({
     layer,

--- a/src/js/atlas/atlasPublicFunctions.js
+++ b/src/js/atlas/atlasPublicFunctions.js
@@ -45,7 +45,7 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
     });
 
     const radiusScale = getRadiusScale({
-      nodes: nationalDataView === 'ta' ? props.nodes : props.msaNodes,
+      nationalMapData,
     });
 
     setNodePositions({
@@ -114,7 +114,7 @@ const getPublicFunctions = ({ privateProps, privateMethods }) => ({
     } = atlasNationalFunctions;
 
     const radiusScale = getRadiusScale({
-      nodes: nationalDataView === 'ta' ? props.nodes : props.msaNodes,
+      nationalMapData,
     });
 
     const updatedNodes = getUpdatedNodes({

--- a/src/js/legend/legend.js
+++ b/src/js/legend/legend.js
@@ -64,6 +64,8 @@ const privateMethods = {
       height,
       width,
       indicator,
+      nationalMapData,
+      radiusScale,
     });
 
     Object.assign(props, {
@@ -138,6 +140,8 @@ class Legend {
       height,
       width,
       indicator,
+      nationalMapData,
+      radiusScale,
     });
   }
 

--- a/src/js/legend/legend.js
+++ b/src/js/legend/legend.js
@@ -56,6 +56,7 @@ const privateMethods = {
       height,
       radiusScale,
       indicator,
+      nationalMapData,
     });
 
     drawDescription({
@@ -129,6 +130,7 @@ class Legend {
       height,
       radiusScale,
       indicator,
+      nationalMapData,
     });
 
     drawDescription({

--- a/src/js/legend/legendFunctions.js
+++ b/src/js/legend/legendFunctions.js
@@ -58,7 +58,7 @@ const legendFunctions = {
       .append('g')
       .attrs({
         class: 'legend__circle-group',
-        transform: d => `translate(${2 + widest},${height - radiusScale(d) - fromBottom})`,
+        transform: d => `translate(${2 + widest},${height - radiusScale(d) - fromBottom + radiusScale(circleData[0])})`,
       });
 
     circleGroups
@@ -106,18 +106,20 @@ const legendFunctions = {
     height,
     width,
     indicator,
+    nationalMapData,
+    radiusScale,
   }) {
+    const circleData = d3.ticks(...d3.extent(nationalMapData, d => d.firstAndLast[1]), 3);
     const {
       getCircleDistanceFromBottom,
     } = localFunctions;
-    const fromTop = height - getCircleDistanceFromBottom({ height });
+    const fromTop = height - getCircleDistanceFromBottom({ height }) + radiusScale(circleData[0]);
     container.select('.legend__description-container').remove();
     container
       .append('div')
       .attr('class', 'legend__description-container')
       .styles({
         width: `${width}px`,
-        height: `${height}px`,
         position: 'absolute',
         left: '0px',
         top: `${fromTop}px`,

--- a/src/js/legend/legendFunctions.js
+++ b/src/js/legend/legendFunctions.js
@@ -8,11 +8,12 @@ const localFunctions = {
 
 const legendFunctions = {
   getRadiusScale({ nationalMapData }) {
-    const domain = d3.extent(nationalMapData, d => d.firstAndLast[1]);
+    const min = d3.min(nationalMapData, d => d.firstAndLast[1]);
+    const mean = d3.mean(nationalMapData, d => d.firstAndLast[1]);
 
     const scale = d3.scaleSqrt()
-      .domain(domain)
-      .range([5, 35]);
+      .domain([min, mean])
+      .range([5, 12]);
 
     return scale;
   },
@@ -34,6 +35,7 @@ const legendFunctions = {
     height,
     radiusScale,
     indicator,
+    nationalMapData,
   }) {
     const format = (val) => {
       const indicatorFormat = indicator.format;
@@ -46,7 +48,7 @@ const legendFunctions = {
     const {
       getCircleDistanceFromBottom,
     } = localFunctions;
-    const circleData = radiusScale.ticks(3);
+    const circleData = d3.ticks(...d3.extent(nationalMapData, d => d.firstAndLast[1]), 3);
     const fromBottom = getCircleDistanceFromBottom({ height });
     svg.selectAll('.legend__circle-group').remove();
     const widest = radiusScale(circleData[circleData.length - 1]);


### PR DESCRIPTION
Just a couple of little issues addressed here, but there are tradeoffs.

1. Radius scale is based on min and _mean_ rather than max, which helps tone down some of the indicators where there are a lot of relatively high values and thus larger circles crowding the map. (e.g. the feedback about paratransit circles being huge). I think it looks pretty good and/or better, though sometimes the legend is less nice.

2. On desktop the whole map starts at a scale related to window size, down to a certain minimum. (Mobile already did this.) Should be okay for laptops now. But note that smaller sizes affect circle packing and increase issues like #89. Also, it's not responsive (never was, apparently) and is only based on the window size on initial load.